### PR TITLE
ESP8266 Delay Fix

### DIFF
--- a/Adafruit_AM2315.cpp
+++ b/Adafruit_AM2315.cpp
@@ -15,7 +15,6 @@
  ****************************************************/
 
 #include "Adafruit_AM2315.h"
-#include <util/delay.h>
 
 Adafruit_AM2315::Adafruit_AM2315() {
 }

--- a/Adafruit_AM2315.cpp
+++ b/Adafruit_AM2315.cpp
@@ -15,6 +15,9 @@
  ****************************************************/
 
 #include "Adafruit_AM2315.h"
+#if defined(__AVR__)
+  #include <util/delay.h>
+#endif
 
 Adafruit_AM2315::Adafruit_AM2315() {
 }


### PR DESCRIPTION
Removes `util/delay.h` include so that the lib compiles for ESP8266 modules.