### PR TITLE
New example to avoid reading temp and humidity less than 2 seconds between each other.

### DIFF
--- a/examples/AM2315_SingleCall
+++ b/examples/AM2315_SingleCall
@@ -1,0 +1,53 @@
+#include <Wire.h>
+#include <Adafruit_AM2315.h>
+
+/***************************************************
+  This is an example for the AM2315 Humidity + Temp sensor
+  Designed specifically to work with the Adafruit BMP085 Breakout
+  ----> https://www.adafruit.com/products/1293
+  These displays use I2C to communicate, 2 pins are required to
+  interface
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  BSD license, all text above must be included in any redistribution
+  
+  Example writen by Leonardo Bispo -> https://github.com/ldab
+ ****************************************************/
+
+// Connect RED of the AM2315 sensor to 5.0V
+// Connect BLACK to Ground
+// Connect WHITE to i2c clock - on '168/'328 Arduino Uno/Duemilanove/etc thats Analog 5
+// Connect YELLOW to i2c data - on '168/'328 Arduino Uno/Duemilanove/etc thats Analog 4
+
+Adafruit_AM2315 am2315;
+
+void setup() {
+
+  Serial.begin(74880);
+  Serial.println("AM2315 Test!");
+
+  if (! am2315.begin()) {
+     Serial.println("Sensor not found, check wiring & pullups!");
+  }
+}
+
+void loop() {
+/*
+ * This method returns both temperature and humidity in a single call and using a single I2C request. 
+ *
+ * If you want to obtain both temperature and humidity when you sample the sensor, be aware that calling 
+ * readTemperature() and readHumidity() in rapid succession may swamp the sensor and result in invalid 
+ * readingings (the AM2315 manual advisess that continuous samples must be at least 2 seconds apart).
+ * Calling this method avoids the double I2C request.
+ */
+  float humidity=NAN;
+  float temperature=NAN;
+  am2315.readTemperatureAndHumidity(temperature, humidity);
+
+  Serial.print("Hum: "); Serial.println(humidity);
+  Serial.print("Temp: "); Serial.println(temperature);
+
+  delay(2500);
+}


### PR DESCRIPTION
This method proved to show more stable and reliable readings:
As with the ```am2315.readHumidity();``` and ```am2315.readTemperature();``` It jumps 2ºC straight away after the second reading:
```
AM2315 Test!
Hum: 44.30
Temp: 20.40
Hum: 44.30
Temp: 20.40
Hum: 44.70
Temp: 22.80
```

Using ```am2315.readTemperatureAndHumidity(temperature, humidity);```:
```
AM2315 Test!
Hum: 44.50
Temp: 20.50
Hum: 44.50
Temp: 20.50
Hum: 44.50
Temp: 20.50
Hum: 44.50
```